### PR TITLE
chore(deps): bump kubernetes

### DIFF
--- a/.github/workflows/metal.yaml
+++ b/.github/workflows/metal.yaml
@@ -38,7 +38,7 @@ jobs:
         run: terraform destroy -target module.metal-app --auto-approve
       - name: Destroy Cluster
         if: always()
-        run: terraform destroy --auto-approve
+        run: terraform destroy --auto-approve -lock=false
 
       - name: Post failure to Slack
         id: slack

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.23.0"
+      version = "3.0.1"
     }
     local = {
       source = "hashicorp/local"

--- a/metal-app/main.tf
+++ b/metal-app/main.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.23.0"
+      version = ">= 3.0.0"
     }
   }
 }
 
-resource "kubernetes_deployment" "nginx" {
+resource "kubernetes_deployment_v1" "nginx" {
   metadata {
     name = "demo"
     labels = {
@@ -39,7 +39,7 @@ resource "kubernetes_deployment" "nginx" {
 
 }
 
-resource "kubernetes_service" "nginx-ingress" {
+resource "kubernetes_service_v1" "nginx-ingress" {
   metadata {
     name = "nginx-ingress"
   }
@@ -47,7 +47,7 @@ resource "kubernetes_service" "nginx-ingress" {
     type = "LoadBalancer"
 
     selector = {
-      app = resource.kubernetes_deployment.nginx.metadata.0.labels.app
+      app = resource.kubernetes_deployment_v1.nginx.metadata.0.labels.app
     }
     port {
       port        = 8080

--- a/metal-infra/main.tf
+++ b/metal-infra/main.tf
@@ -8,7 +8,7 @@ terraform {
 
 resource "metal_cluster" "app_cluster" {
   name       = var.cluster_name
-  kubernetes = "1.32.6"
+  kubernetes = "1.33.7"
   workers = [
     {
       name            = "default"

--- a/metal-infra/main.tf
+++ b/metal-infra/main.tf
@@ -8,7 +8,7 @@ terraform {
 
 resource "metal_cluster" "app_cluster" {
   name       = var.cluster_name
-  kubernetes = "1.33.7"
+  kubernetes = "1.33.8"
   workers = [
     {
       name            = "default"


### PR DESCRIPTION
- version of hashicorp/kubernetes
- latest kubernetes version on metalstack.cloud

## AI Transparency

No AI was used.